### PR TITLE
TII-198 small tweak in reports job logic

### DIFF
--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinReviewServiceImpl.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinReviewServiceImpl.java
@@ -2350,7 +2350,7 @@ public class TurnitinReviewServiceImpl extends BaseReviewServiceImpl {
 			if (currentItem.getNextRetryTime() == null)
 				currentItem.setNextRetryTime(new Date());
 
-			if (currentItem.getNextRetryTime().after(new Date())) {
+			else if (currentItem.getNextRetryTime().after(new Date())) {
 				//we haven't reached the next retry time
 				log.info("next retry time not yet reached for item: " + currentItem.getId());
 				dao.update(currentItem);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/TII-198

This should be an if/else, rather than an if/if. If it's null (the first condition), we set it to the current date. Then why immediately after, would we additionally check if that new date is after another new date of now.
