### PR TITLE
TII-199 fix grademark integration logic to obey arbitrary decimal points in Assignments

### DIFF
--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinReviewServiceImpl.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinReviewServiceImpl.java
@@ -58,10 +58,8 @@ import org.apache.commons.validator.EmailValidator;
 import org.tsugi.basiclti.BasicLTIConstants;
 import org.sakaiproject.api.common.edu.person.SakaiPerson;
 import org.sakaiproject.api.common.edu.person.SakaiPersonManager;
-//import org.sakaiproject.assignment.api.Assignment;
 import org.sakaiproject.assignment.api.AssignmentContent;
 import org.sakaiproject.assignment.api.AssignmentContentEdit;
-import org.sakaiproject.assignment.api.AssignmentEdit;
 import org.sakaiproject.assignment.api.AssignmentService;
 import org.sakaiproject.assignment.api.AssignmentSubmission;
 import org.sakaiproject.authz.api.SecurityAdvisor;
@@ -1251,7 +1249,16 @@ public class TurnitinReviewServiceImpl extends BaseReviewServiceImpl {
 			
 			ltiProps = putInstructorInfo(ltiProps, siteId);
 
-			ltiProps.put("custom_maxpoints", extraAsnnOpts.get("points").toString());
+			/*
+			 * Force TII max points to 100 so we can interpret the result as a direct percentage.
+			 * This is done because Assignments now has the ability to grade to an arbitrary number of decimal places.
+			 * Due to the limitation of TII requiring whole integers for grading, we would have to inflate the grade by a
+			 * factor to the power of the number of decimal places allowed. This would result in unusually large numbers
+			 * on the TII, which could be confusing for the end user.
+			 */
+			ltiProps.put("custom_maxpoints", "100");
+			custom += "\n" + "custom_maxpoints=100";
+
 	        ltiProps.put("custom_studentpapercheck", extraAsnnOpts.get("s_paper_check").toString());
 	        ltiProps.put("custom_journalcheck",extraAsnnOpts.get("journal_check").toString());
 
@@ -1262,7 +1269,6 @@ public class TurnitinReviewServiceImpl extends BaseReviewServiceImpl {
 			//ONLY FOR TII UK
 			//ltiProps.setProperty("custom_anonymous_marking_enabled", extraAsnnOpts.get("s_paper_check"));
 			
-			custom += "\n" + "custom_maxpoints=" + extraAsnnOpts.get("points").toString();
 			custom += "\n" + "custom_studentpapercheck=" + extraAsnnOpts.get("s_paper_check").toString();
 			custom += "\n" + "custom_journalcheck=" + extraAsnnOpts.get("journal_check").toString();
 			custom += "\n" + "custom_internetcheck=" + extraAsnnOpts.get("internet_check").toString();

--- a/contentreview-impl/tool/src/java/org/sakaiproject/contentreview/servlet/GradingCallbackServlet.java
+++ b/contentreview-impl/tool/src/java/org/sakaiproject/contentreview/servlet/GradingCallbackServlet.java
@@ -37,9 +37,11 @@ import org.sakaiproject.component.cover.ComponentManager;
 import org.sakaiproject.component.cover.ServerConfigurationService;
 import org.sakaiproject.contentreview.model.ContentReviewItem;
 import org.sakaiproject.contentreview.service.ContentReviewService;
+import org.sakaiproject.exception.IdUnusedException;
+import org.sakaiproject.exception.InUseException;
+import org.sakaiproject.exception.PermissionException;
 import org.sakaiproject.lti.api.LTIService;
-import org.sakaiproject.tool.api.Session;
-import org.sakaiproject.tool.cover.SessionManager;
+import org.w3c.dom.DOMException;
 
 /** 
  * This servlet will receive callbacks from TII. Then it will process the data
@@ -48,9 +50,14 @@ import org.sakaiproject.tool.cover.SessionManager;
 
 @SuppressWarnings("deprecation")
 public class GradingCallbackServlet extends HttpServlet {
-	
+
 	private static Log M_log = LogFactory.getLog(GradingCallbackServlet.class);
-	
+
+	private static final String SAK_PROP_ENABLE_GRADEMARK = "turnitin.grademark.integration.enabled";
+	private static final boolean SAK_PROP_ENABLE_GRADEMARK_DEFAULT = true;
+	private static final boolean GRADEMARK_INTEGRATION_ENABLED = ServerConfigurationService.getBoolean( SAK_PROP_ENABLE_GRADEMARK, SAK_PROP_ENABLE_GRADEMARK_DEFAULT );
+	private static final String DEBUG_MSG_GRADEMARK_DISABLED = "TII Grademark integration disabled in sakai.properties; aborting.";
+
 	private ContentReviewService contentReviewService;
 	private LTIService ltiService;
 
@@ -63,168 +70,181 @@ public class GradingCallbackServlet extends HttpServlet {
 		Objects.requireNonNull(ltiService);
 		super.init(config);
 	}
-	
+
 	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		M_log.debug("doGet GradingCallbackServlet");
-		doPost(request, response);
+		if( GRADEMARK_INTEGRATION_ENABLED ) {
+			M_log.debug("doGet GradingCallbackServlet");
+			doPost(request, response);
+		}
+		else {
+			M_log.debug( DEBUG_MSG_GRADEMARK_DISABLED );
+		}
 	}
-	
+
 	@SuppressWarnings("unchecked")
 	protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		M_log.debug("doPost GradingCallbackServlet");
-		String ipAddress = request.getRemoteAddr();
-		M_log.debug("Service request from IP=" + ipAddress);
-		
-		String allowOutcomes = ServerConfigurationService.getString(SakaiBLTIUtil.BASICLTI_OUTCOMES_ENABLED, SakaiBLTIUtil.BASICLTI_OUTCOMES_ENABLED_DEFAULT);
-		if ( ! "true".equals(allowOutcomes) ) allowOutcomes = null;
+		if( GRADEMARK_INTEGRATION_ENABLED ) {
+			M_log.debug("doPost GradingCallbackServlet");
+			String ipAddress = request.getRemoteAddr();
+			M_log.debug("Service request from IP=" + ipAddress);
 
-		if (allowOutcomes == null ) {
-			M_log.warn("LTI Services are disabled IP=" + ipAddress);
-			response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-			return;
+			String allowOutcomes = ServerConfigurationService.getString(SakaiBLTIUtil.BASICLTI_OUTCOMES_ENABLED, SakaiBLTIUtil.BASICLTI_OUTCOMES_ENABLED_DEFAULT);
+			if ( ! "true".equals(allowOutcomes) ) allowOutcomes = null;
+
+			if (allowOutcomes == null ) {
+				M_log.warn("LTI Services are disabled IP=" + ipAddress);
+				response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+				return;
+			}
+
+			String contentType = request.getContentType();
+			if ( contentType != null && contentType.startsWith("application/xml") ) {
+				doPostXml(request, response);
+			} else {
+				M_log.warn("GradingCallbackServlet received a not xml call. Callback should have a Content-Type header of application/xml.");
+				response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+			}
 		}
-		
-		String contentType = request.getContentType();
-		if ( contentType != null && contentType.startsWith("application/xml") ) {
-			doPostXml(request, response);
-		} else {
-			M_log.warn("GradingCallbackServlet received a not xml call. Callback should have a Content-Type header of application/xml.");
-			response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+		else {
+			M_log.debug( DEBUG_MSG_GRADEMARK_DISABLED );
 		}
 	}
-	
+
 	@SuppressWarnings("unchecked")
-    protected void doPostXml(HttpServletRequest request, HttpServletResponse response) 
-            throws ServletException, IOException 
-    {
-		M_log.debug("doPostXml GradingCallbackServlet");
-		IMSPOXRequest poxRequest = new IMSPOXRequest(request);
-		if ( poxRequest.valid ) {
-			M_log.debug(poxRequest.getPostBody());
-		}
-		
-		String turnitinSite = ServerConfigurationService.getString("turnitin.lti.site", "!turnitin");
-		Map<String,Object> tiiData = ServletUtils.obtainGlobalTurnitinLTITool(turnitinSite);
-		if(tiiData == null){
-			M_log.error("Turnitin global LTI tool does not exist or properties are wrongly configured.");
-		}
-		String key = String.valueOf(tiiData.get(LTIService.LTI_CONSUMERKEY));
-		String secret = String.valueOf(tiiData.get(LTIService.LTI_SECRET));
-		
-		// Lets check the signature
-		if ( key == null || secret == null ) {
-			M_log.debug("doPostJSON Deployment is missing credentials");
-			response.setStatus(HttpServletResponse.SC_FORBIDDEN); 
-			doErrorXML(request, response, poxRequest, "Deployment is missing credentials", null);
-			return;
-		}
+	protected void doPostXml(HttpServletRequest request, HttpServletResponse response) 
+			throws ServletException, IOException 
+	{
+		if( GRADEMARK_INTEGRATION_ENABLED ) {
+			M_log.debug("doPostXml GradingCallbackServlet");
+			IMSPOXRequest poxRequest = new IMSPOXRequest(request);
+			if ( poxRequest.valid ) {
+				M_log.debug(poxRequest.getPostBody());
+			}
 
-		poxRequest.validateRequest(key, secret, request);
-		if ( !poxRequest.valid ) {
-			M_log.debug("doPostJSON OAuth signature failure");
-			response.setStatus(HttpServletResponse.SC_FORBIDDEN); 
-			doErrorXML(request, response, poxRequest, "OAuth signature failure", null);
-			return;
-		}
-		
-		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-		String sourcedId = null;
-		SecurityService securityService = (SecurityService) ComponentManager.get(SecurityService.class);
-		SecurityAdvisor yesMan = (String userId, String function, String reference)->{return SecurityAdvice.ALLOWED;};
-        try{
-			DocumentBuilder builder = factory.newDocumentBuilder();
-			Document document = builder.parse(new InputSource(new StringReader(poxRequest.getPostBody())));
-			Element doc = document.getDocumentElement();
-			sourcedId = doc.getElementsByTagName("sourcedId").item(0).getChildNodes().item(0).getNodeValue();
-			String score = doc.getElementsByTagName("textString").item(0).getChildNodes().item(0).getNodeValue();//catched exception if textString is null
-			//TODO if they remove grade it's considered as an exception and sakai external grade is not updated
-			M_log.debug("sourcedId " + sourcedId + ", score " + score);
-			securityService.pushAdvisor(yesMan);
+			String turnitinSite = ServerConfigurationService.getString("turnitin.lti.site", "!turnitin");
+			Map<String,Object> tiiData = ServletUtils.obtainGlobalTurnitinLTITool(turnitinSite);
+			if(tiiData == null){
+				M_log.error("Turnitin global LTI tool does not exist or properties are wrongly configured.");
+			}
+			String key = String.valueOf(tiiData.get(LTIService.LTI_CONSUMERKEY));
+			String secret = String.valueOf(tiiData.get(LTIService.LTI_SECRET));
 
-			if(contentReviewService == null){
-				M_log.warn("Can't find contentReviewService");
+			// Lets check the signature
+			if ( key == null || secret == null ) {
+				M_log.debug("doPostJSON Deployment is missing credentials");
+				response.setStatus(HttpServletResponse.SC_FORBIDDEN); 
+				doErrorXML(request, response, poxRequest, "Deployment is missing credentials", null);
 				return;
 			}
-			ContentReviewItem cri = contentReviewService.getFirstItemByContentId(sourcedId);
-			if(cri == null){
-				M_log.info("Could not find the content review item for content " + sourcedId);
-				cri = contentReviewService.getFirstItemByExternalId(sourcedId);
-			}
-			if(cri == null){
-				M_log.warn("Could not find the content review item for paper id " + sourcedId);
+
+			poxRequest.validateRequest(key, secret, request);
+			if ( !poxRequest.valid ) {
+				M_log.debug("doPostJSON OAuth signature failure");
+				response.setStatus(HttpServletResponse.SC_FORBIDDEN); 
+				doErrorXML(request, response, poxRequest, "OAuth signature failure", null);
 				return;
-			} else {
-				Assignment a = AssignmentService.getAssignment(cri.getTaskId());
-				AssignmentContent ac = a.getContent();
-				if(ac == null){
-					M_log.debug("Could not find the assignment content " + cri.getTaskId());
+			}
+
+			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+			String sourcedId = null;
+			SecurityService securityService = (SecurityService) ComponentManager.get(SecurityService.class);
+			SecurityAdvisor yesMan = (String userId, String function, String reference)->{return SecurityAdvice.ALLOWED;};
+			try{
+				DocumentBuilder builder = factory.newDocumentBuilder();
+				Document document = builder.parse(new InputSource(new StringReader(poxRequest.getPostBody())));
+				Element doc = document.getDocumentElement();
+				sourcedId = doc.getElementsByTagName("sourcedId").item(0).getChildNodes().item(0).getNodeValue();
+				String score = doc.getElementsByTagName("textString").item(0).getChildNodes().item(0).getNodeValue();//catched exception if textString is null
+				//TODO if they remove grade it's considered as an exception and sakai external grade is not updated
+				M_log.debug("sourcedId " + sourcedId + ", score " + score);
+				securityService.pushAdvisor(yesMan);
+
+				if(contentReviewService == null){
+					M_log.warn("Can't find contentReviewService");
 					return;
+				}
+				ContentReviewItem cri = contentReviewService.getFirstItemByContentId(sourcedId);
+				if(cri == null){
+					M_log.info("Could not find the content review item for content " + sourcedId);
+					cri = contentReviewService.getFirstItemByExternalId(sourcedId);
+				}
+				if(cri == null){
+					M_log.warn("Could not find the content review item for paper id " + sourcedId);
 				} else {
-					M_log.debug("Got assignment content " + cri.getTaskId());
-				}
-				/* TODO on trunk more than one decimal is possible
-				int factor = AssignmentService.getScaleFactor();
-				int dec = (int)Math.log10(factor);
-				int maxPoints = assign.getMaxGradePoint() / dec;*/
-				int maxPoints = ac.getMaxGradePoint() / 10;
-				if(maxPoints == 0){//assignment grades might not be numeric
-					return;
-				}
-				float convertedScore = Float.valueOf(score)*maxPoints;
-				String convertedScoreString = String.format("%.0f", convertedScore);
-				M_log.debug("Maximum points: " + maxPoints + " - converted score: " + convertedScoreString);
-				
-				M_log.debug("cri " + cri.getId() + " - " + cri.getContentId());
-				boolean itemUpdated = contentReviewService.updateExternalGrade(cri.getContentId(), convertedScoreString);
-				if(!itemUpdated){
-					M_log.error("Could not update cr item external grade for content " + cri.getContentId());
-					return;
-				}
-				
-				if(convertedScore >= 0){
-					if(ac.getTypeOfSubmission() != 5 && ac.getTypeOfSubmission() != 1){
-						M_log.debug(ac.getTypeOfSubmission() + " is the type setting for task " + cri.getTaskId());
+					Assignment a = AssignmentService.getAssignment(cri.getTaskId());
+					AssignmentContent ac = a.getContent();
+					if(ac == null){
+						M_log.debug("Could not find the assignment content " + cri.getTaskId());
 						return;
 					} else {
-						AssignmentSubmissionEdit ase = AssignmentService.editSubmission(cri.getSubmissionId());
-						if(ase != null){
-							String assignmentGrade = ase.getGrade();
-							if(StringUtils.isEmpty(assignmentGrade)){
-								M_log.debug("Setting external grade as assignments grade");
-								convertedScoreString = String.format("%.1f", convertedScore);//TODO on trunk more than one decimal is possible
-								ase.setGrade(convertedScoreString);
-							} else {
-								M_log.debug("Flagging submission");
-								ase.setExternalGradeDifferent(Boolean.TRUE.booleanValue());
+						M_log.debug("Got assignment content " + cri.getTaskId());
+					}
+
+					int factor = AssignmentService.getScaleFactor();
+					int dec = (int)Math.log10(factor);
+					int maxPoints = ac.getMaxGradePoint() / factor;
+					if(maxPoints == 0){//assignment grades might not be numeric
+						return;
+					}
+					double convertedScore = Double.valueOf(score)*maxPoints;
+					String convertedScoreString = String.format("%." + dec + "f", convertedScore);
+					M_log.debug("Maximum points: " + maxPoints + " - converted score: " + convertedScoreString);
+
+					M_log.debug("cri " + cri.getId() + " - " + cri.getContentId());
+					boolean itemUpdated = contentReviewService.updateExternalGrade(cri.getContentId(), convertedScoreString);
+					if(!itemUpdated){
+						M_log.error("Could not update cr item external grade for content " + cri.getContentId());
+						return;
+					}
+
+					if(convertedScore >= 0){
+						if(ac.getTypeOfSubmission() != 5 && ac.getTypeOfSubmission() != 1){
+							M_log.debug(ac.getTypeOfSubmission() + " is the type setting for task " + cri.getTaskId());
+						} else {
+							AssignmentSubmissionEdit ase = AssignmentService.editSubmission(cri.getSubmissionId());
+							if(ase != null){
+								String assignmentGrade = ase.getGrade();
+								if(StringUtils.isEmpty(assignmentGrade)){
+									M_log.debug("Setting external grade as assignments grade");
+									convertedScoreString = String.format("%." + dec + "f", convertedScore);
+									ase.setGrade(convertedScoreString);
+								} else {
+									M_log.debug("Flagging submission");
+									ase.setExternalGradeDifferent(Boolean.TRUE);
+								}
+								AssignmentService.commitEditFromCallback(ase);
 							}
-							AssignmentService.commitEditFromCallback(ase);
 						}
 					}
 				}
+			} catch(ParserConfigurationException pce){
+				M_log.error("Could not parse TII response (ParserConfigurationException): " + pce.getMessage());
+			} catch(SAXException se){
+				M_log.error("Could not parse TII response (SAXException): " + se.getMessage());
+			} catch(IOException | DOMException | IdUnusedException | PermissionException | NumberFormatException | InUseException e){
+				M_log.error("Could not update the content review item " + sourcedId, e);
 			}
-		} catch(ParserConfigurationException pce){
-			M_log.error("Could not parse TII response (ParserConfigurationException): " + pce.getMessage());
-		} catch(SAXException se){
-			M_log.error("Could not parse TII response (SAXException): " + se.getMessage());
-		} catch(Exception e){
-			M_log.error("Could not update the content review item " + sourcedId);
+			finally
+			{
+				securityService.popAdvisor(yesMan);
+			}
 		}
-		finally
-		{
-			securityService.popAdvisor(yesMan);
+		else {
+			M_log.debug( DEBUG_MSG_GRADEMARK_DISABLED );
 		}
+	}
 
-        return;
-    }
-	
-	public void doErrorXML(HttpServletRequest request,HttpServletResponse response, 
-			IMSPOXRequest pox, String message, Exception e) 
+	public void doErrorXML(HttpServletRequest request,HttpServletResponse response, IMSPOXRequest pox, String message, Exception e) 
 		throws java.io.IOException 
 	{
-		if (e != null) {
-			M_log.error(e.getLocalizedMessage(), e);
+		if( GRADEMARK_INTEGRATION_ENABLED ) {
+			if (e != null) {
+				M_log.error(e.getLocalizedMessage(), e);
+			}
+			M_log.warn(message);
 		}
-        M_log.warn(message);
-    }
-
+		else {
+			M_log.debug( DEBUG_MSG_GRADEMARK_DISABLED );
+		}
+	}
 }


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/TII-199

Currently, the max points from Assignments is inflated by a factor of 10 when sent to TII. Therefore, if your assignment is out of 10 in Assignments, it will be out of 100 in TII; if your assignment is out of 15 in Assignments, it will be out of 150 in TII.

This is likely due to the fact that the original developer(s) wrote the code under the assumption that you can only have a maximum of 1 decimal place when grading in Assignments. Due to the limitation that you cannot use decimal places in the TII side, they chose to send the max points value inflated by a factor of 10. Then when the grade comes back from TII, the code scales it back by a factor of 10.

However, now that we're able to grade to an arbitrary number of decimal places in Assignments, this paradigm becomes unwieldy when considering the implications on the TII side. For instance, if an institution allows grading to 2 decimal places in Assignments, and an instructor elects to make their assignment out of 10, then this would necessitate that the Grademark be out of 1000 on the TII side, to properly accommodate 2 decimal places coming back into Sakai.

As the number of decimal places increases, so to does the factor by which the grade has to be multiplied on the TII side, resulting in very high numbers. This can be both confusing and awkward for the end user.

A solution to this problem, is to force the Grademark in TII to always be out of 100, regardless of what the Assignment is out of in Sakai. In this way, the Grademark grade can be thought of by the end user, and interpreted by Sakai as a direct percentage. In this way, the grade in Assignments can easily be determined as the same percentage, but out of the total value which the instructor/maintainer has chosen for the Assignment, and it can include however many decimal places the institution allows.

We've also introduced a sakai.property to control whether or not Sakai accepts Grademark grades coming back into the system (which defaults to true):

"turnitin.grademark.integration.enabled"
