### PR TITLE
TII-199 update README.md with sakai.properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The new implementation of turnitin for Sakai 11.0
+# The new implementation of turnitin for Sakai 11.0
 
 This is based on Oxford's code, but with slight changes for
 the current state of 11.x ,and a couple of bug fixes and
@@ -9,7 +9,7 @@ improvements. This will track Rutgers production code.
 * sakai.properties has the properties I used for debugging. This includes
   our properties for the old implementation, so it may have more than you need
 
-Steps to make this work:
+## Steps to make this work:
 
 * Have your TurnitIn administrator contact Turnitin to enable the LTI integration for you. Once they have, your administrator will need to login, go to integrations, and configure it. The output of this will be a secret key (which you choose) and the numeric account number of your account at TII.
 * Once you’ve built the code and started Sakai, login as admin. You need to add Turnitin as an LTI tool in “External tools”. Here’s Oxford’s instructions:
@@ -18,12 +18,12 @@ Steps to make this work:
 ** Content Review Reports
 You will have to run jobs manually unless they're set up to auto-run. for testing I've been running them manually when needed
 
-LTI setup
+## LTI setup
 
 * As admin, create a site that you’ll install the turnitin API tool into. If you can manage to set the siteid to !turnitin, do so. For me the admin site interface doesn’t let me choose the site ID. Once you create the site, remember the ID.
 * Add an LTI tool via Admin Workspace > External Tools. The configuration for the tool on LIVE should be
 
-Properties for LTI tool:
+## Properties for LTI tool:
 
 * Site ID: !turnitin [or whatever site ID your site uses]
 * Tool Title: Turnitin
@@ -35,7 +35,7 @@ Properties for LTI tool:
 * Tool visibility: stealthed [I don’t recommend this. It makes it hard to add the tool to the site]
 * Launch URL - https://api.turnitinuk.com/api/lti/1p0/assignment or equivalent for the US, Spain etc.
 
-For most people this will be https://api.turnitin.com/api/lti/1p0/assignment
+## For most people this will be https://api.turnitin.com/api/lti/1p0/assignment
 
 * Do not allow URL to be changed
 * Tool Key - nnnn - your Turnitin account number
@@ -57,7 +57,35 @@ Note that properties aren’t identical in the current version of 11 to the list
 
 More details at: http://turnitin.com/en_us/support/integrations/lti/
 
-Starting
+## Sakai.properties
+
+The following sakai.properties are relevant to the Turnitin LTI integration:
+
+##### turnitin.lti.site
+* This is the ID of the LTI tool you created above (likely "!turnitin)
+* There is no default for this property
+
+##### turnitin.grademark.integration.enabled
+* Enables or disables the ability for Sakai to receive Grademark grades from Turnitin
+* Defaults to "true"
+
+##### turnitin.maxRetry
+* Defines the maximum number of times an item (submission) will attempt to be submitted to Turnitin
+* Defaults to "100"
+
+##### turnitin.enable.assignment2
+##### turnitin.apiURL
+##### turnitin.secretKey
+##### turnitin.said
+##### turnitin.aid
+##### turnitin.useSourceParameter
+##### turnitin.generate.last.name
+##### turnitin.option.institution_check
+##### turnitin.ltiURL
+##### assignment.useContentReview
+##### assignment.useContentReviewLTI
+
+## Starting
 
 Once you’re created the LTI tool, go to the turnitin Sakai site and add the tool. You should be able to do add tool. Turnitin should show under "plugins" in the tool list, unless you stealthed it.
 
@@ -65,7 +93,7 @@ Configure turnitin in sakai.properties and restart. See sakai.properties here.
 
 That file includes the values we were using for the old interface. I’m not sure whether you can remove them or not.
 
-WARNING:
+## WARNING:
 
 If you have used other code, your database may have a definition for
 CONTENTREVIEW_ITEM that will prevent Content Review from being able to


### PR DESCRIPTION
Updated the README with the sakai.property for enabling/disabling Grademark, as well as other properties related to TII which were not documented.
