### PR TITLE
TII-200 handle content review minimum and maximum for assignment titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,30 @@ The following sakai.properties are relevant to the Turnitin LTI integration:
 * Defines the maximum number of times an item (submission) will attempt to be submitted to Turnitin
 * Defaults to "100"
 
+##### contentreview.site.min=5
+* Defines the minimum number of characters allowed in a site title by Turnitin
+* Defaults to "0"
+* You **must** set this to 5 for use with Turnitin
+* If you don't set this property, the integration will fail in sites with titles less than 5 characters, and this error will not be apparent to the end user
+
+##### contentreview.site.max=50
+* Defines the maximum number of characters allowed in a site title by Turnitin
+* Defaults to "0"
+* You **must** set this to 50 for use with Turnitin
+* If you don't set this property, the integration will fail in sites with titles greater than 50 characters, and this error will not be apparent to the end user
+
+##### contentreview.assign.min=3
+* Defines the minimum number of characters allowed in an assignment title by Turnitin
+* Defaults to "0"
+* You **must** set this to 3 for use with Turnitin
+* If you don't set this property, the integration will fail in sites with assignment titles less than 3 characters, and this error will not be apparent to the end user
+
+##### contentreview.assign.max=100
+* Defines the maximum number of characters allowed in an assignment title by Turnitin
+* Defaults to "0"
+* You **must** set this to 100 for use with Turnitin
+* If you don't set this property, the integration will fail in sites with assignment titles greater than 100 characters, and this error will not be apparent to the end user
+
 ##### turnitin.enable.assignment2
 ##### turnitin.apiURL
 ##### turnitin.secretKey


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/TII-200

If you try to create an assignment with less than 3 characters in the title, Turnitin responds with an error like so:

```
<div id="api_errorblock">
<h2>Sorry, we could not process your request</h2>
<p>Turnitin assignment could not be created.
title - Input must be at least 3 characters. You submitted 2
</p>
</div>
```

This means we can't scrape the id, and Turnitin doesn't make the callback, but the assignment never goes to draft mode because TIIUtil.makeLTIcall still returns 1.

There is already code intended to perform this validation, but it isn't actually checking anything. You have to set the relevant sakai.properties (which default to zero), and alter the code (PR).
