### PR TITLE
TII-201 fix isUrlAccessed field updating, modify logic to allow or deny serving the file

### DIFF
--- a/contentreview-impl/hbm/src/java/org/sakaiproject/contentreview/hbm/ContentReviewItem.hbm.xml
+++ b/contentreview-impl/hbm/src/java/org/sakaiproject/contentreview/hbm/ContentReviewItem.hbm.xml
@@ -26,7 +26,7 @@
         <property name="retryCount" type="long" not-null="false" />
         <property name="nextRetryTime" type="java.util.Date" not-null="false"/>
         <property name="errorCode" type="integer" not-null="false"/>
-        <property name="urlAccessed" type="boolean">
+        <property name="urlAccessed" type="boolean" insert="true" update="false">
 			<column name="urlAccessed" not-null="true" default="false" />
         </property>
         <property name="submissionId" type="string" length="255" not-null="false" />

--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/dao/impl/ContentReviewDao.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/dao/impl/ContentReviewDao.java
@@ -61,5 +61,11 @@ public interface ContentReviewDao extends CompleteGenericDao {
 	   @SuppressWarnings("unchecked")
 	   public Boolean releaseLock(String lockId, String executerId);
 	
-	
+	   /**
+	    * Updates the 'isUrlAccessed' field of the content review item with the specified boolean value
+	    * @param contentID the content ID of the content review item to be updated
+	    * @param isUrlAccessed the boolean value to be updated for the given content review item
+	    * @return whether the update was successful
+	    */
+	   public boolean updateIsUrlAccessed( String contentID, boolean isUrlAccessed );
 }

--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/dao/impl/ContentReviewDaoImpl.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/dao/impl/ContentReviewDaoImpl.java
@@ -26,9 +26,11 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.hibernate.SQLQuery;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
 import org.sakaiproject.contentreview.model.ContentReviewLock;
 import org.sakaiproject.genericdao.hibernate.HibernateCompleteGenericDao;
-import org.sakaiproject.contentreview.dao.impl.ContentReviewDao;
 
 /**
  * Implementations of any specialized DAO methods from the specialized DAO 
@@ -39,7 +41,9 @@ public class ContentReviewDaoImpl
 	extends HibernateCompleteGenericDao 
 		implements ContentReviewDao {
 
-	private static Log log = LogFactory.getLog(ContentReviewDaoImpl.class);
+	private static final Log log = LogFactory.getLog(ContentReviewDaoImpl.class);
+
+	private static final String SQL_UPDATE_IS_URL_ACCESSED = "UPDATE contentreview_item SET urlAccessed = :isUrlAccessed WHERE contentId = :contentID";
 
 	public void init() {
 		log.debug("init");
@@ -48,6 +52,22 @@ public class ContentReviewDaoImpl
 		} catch (Exception e) {
 			log.error(e);
 		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public boolean updateIsUrlAccessed( String contentID, boolean isUrlAccessed )
+	{
+		Session session = getSessionFactory().openSession();
+		Transaction tx = session.beginTransaction();
+		SQLQuery query = session.createSQLQuery( SQL_UPDATE_IS_URL_ACCESSED );
+		query.setParameter( "isUrlAccessed", isUrlAccessed );
+		query.setParameter( "contentID", contentID );
+		int result = query.executeUpdate();
+		tx.commit();
+		session.close();
+		return result > 0;
 	}
 
 	/**

--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/hbm/BaseReviewServiceImpl.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/hbm/BaseReviewServiceImpl.java
@@ -181,7 +181,7 @@ public abstract class BaseReviewServiceImpl implements ContentReviewService {
 		Search search = new Search();
 		search.addRestriction(new Restriction("contentId", contentId));
 		List<ContentReviewItem> existingItems = dao.findBySearch(ContentReviewItem.class, search);
-		if (existingItems.size() == 0) {
+		if (existingItems.isEmpty()) {
 			log.debug("Content " + contentId + " has not been queued previously");
 			return null;
 		}
@@ -200,7 +200,7 @@ public abstract class BaseReviewServiceImpl implements ContentReviewService {
 		search.addRestriction(new Restriction("externalId", externalId));
 		search.addOrder(new Order("id", false));
 		List<ContentReviewItem> existingItems = dao.findBySearch(ContentReviewItem.class, search);
-		if (existingItems.size() == 0) {
+		if (existingItems.isEmpty()) {
 			log.debug("Content with paper id " + externalId + " has not been queued previously");
 			return null;
 		}
@@ -216,7 +216,7 @@ public abstract class BaseReviewServiceImpl implements ContentReviewService {
 		Search search = new Search();
 		search.addRestriction(new Restriction("id", Long.valueOf(id)));
 		List<ContentReviewItem> existingItems = dao.findBySearch(ContentReviewItem.class, search);
-		if (existingItems.size() == 0) {
+		if (existingItems.isEmpty()) {
 			log.debug("Content " + id + " has not been queued previously");
 			return null;
 		}
@@ -233,7 +233,7 @@ public abstract class BaseReviewServiceImpl implements ContentReviewService {
 		log.debug("Getting review score for content: " + contentId);
 
 		List<ContentReviewItem> matchingItems = getItemsByContentId(contentId);
-		if (matchingItems.size() == 0) {
+		if (matchingItems.isEmpty()) {
 			log.debug("Content " + contentId + " has not been queued previously");
 			throw new QueueException("Content " + contentId + " has not been queued previously");
 		}
@@ -247,7 +247,7 @@ public abstract class BaseReviewServiceImpl implements ContentReviewService {
 			throw new ReportException("Report not available: " + item.getStatus());
 		}
 		
-		return item.getReviewScore().intValue();
+		return item.getReviewScore();
 	}
 
 	
@@ -258,7 +258,7 @@ public abstract class BaseReviewServiceImpl implements ContentReviewService {
 
 		List<ContentReviewItem> matchingItems = getItemsByContentId(contentId);
 		
-		if (matchingItems.size() == 0) {
+		if (matchingItems.isEmpty()) {
 			log.debug("Content " + contentId + " has not been queued previously");
 			throw new QueueException("Content " + contentId + " has not been queued previously");
 		}
@@ -274,7 +274,7 @@ public abstract class BaseReviewServiceImpl implements ContentReviewService {
 		log.debug("Returning date queued for content: " + contentId);
 
 		List<ContentReviewItem> matchingItems = getItemsByContentId(contentId);
-		if (matchingItems.size() == 0) {
+		if (matchingItems.isEmpty()) {
 			log.debug("Content " + contentId + " has not been queued previously");
 			throw new QueueException("Content " + contentId + " has not been queued previously");
 		}
@@ -291,7 +291,7 @@ public abstract class BaseReviewServiceImpl implements ContentReviewService {
 
 		List<ContentReviewItem> matchingItems = getItemsByContentId(contentId);
 		
-		if (matchingItems.size() == 0) {
+		if (matchingItems.isEmpty()) {
 			log.debug("Content " + contentId + " has not been queued previously");
 			throw new QueueException("Content " + contentId + " has not been queued previously");
 		}
@@ -376,13 +376,7 @@ public abstract class BaseReviewServiceImpl implements ContentReviewService {
 	}
 
 	public boolean updateItemAccess(String contentId){
-		ContentReviewItem cri = getFirstItemByContentId(contentId);
-		if(cri != null){
-			cri.setUrlAccessed(true);
-			dao.update(cri);
-			return true;
-		}
-		return false;
+		return dao.updateIsUrlAccessed( contentId, true );
 	}
 		
 	public boolean updateExternalGrade(String contentId, String score){
@@ -453,10 +447,4 @@ public abstract class BaseReviewServiceImpl implements ContentReviewService {
 		// TODO Auto-generated method stub
 		
 	}
-
-	
-
-
-	
-
 }

--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinReviewServiceImpl.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinReviewServiceImpl.java
@@ -1924,7 +1924,7 @@ public class TurnitinReviewServiceImpl extends BaseReviewServiceImpl {
 			//////////////////////////////  NEW LTI INTEGRATION  ///////////////////////////////
 			if(siteAdvisor.siteCanUseLTIReviewService(s) && currentItem.getSubmissionId()!=null){
 				
-				Map<String,String> ltiProps = new HashMap<String,String> ();	
+				Map<String,String> ltiProps = new HashMap<>();
 				ltiProps.put("context_id", currentItem.getSiteId());
 				ltiProps.put("resource_link_id", currentItem.getTaskId());
 				ltiProps.put("roles", "Learner");
@@ -1938,7 +1938,7 @@ public class TurnitinReviewServiceImpl extends BaseReviewServiceImpl {
 				String[] parts = currentItem.getTaskId().split("/");
 				log.debug(parts[parts.length -1] + " " + parts.length);
 				String httpAccess = serverConfigurationService.getServerUrl() + "/access/assignment/s/" + currentItem.getSiteId() + "/" + parts[parts.length -1] + "/" + currentItem.getSubmissionId();
-				httpAccess += ":" + currentItem.getId();
+				httpAccess += ":" + currentItem.getId() + ":" + currentItem.getContentId().hashCode();
 				log.debug("httpAccess url: " + httpAccess);//debug
 				ltiProps.put("custom_submission_url", httpAccess);
 				ltiProps.put("custom_submission_title", fileName);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/TII-201

There is a new contentreviewitem property called isUrlAccessed which controls whether or not a submission in the queue (file) can be retrieved by Turnitin. Before granting access to the file resource (in BaseAssignmentService.getHttpAccess()), it checks this property and returns early if it is true.

After many, many iterations of testing and debugging, it seems that there's a race condition happening here.

The TII callback to retrieve the file happens very quickly, and sets the isUrlAccessed to true. Milliseconds later, the queue job continues on, and does some unrelated updates to the same contentReviewItem. Now, because the queue job is using the DAO to update the object, regardless of if it's explicitly setting the isUrlAccessed attribute or not, Hibernate will update this field to the default value.

So, TII gets the file, sets the isURLAccessed to true, then the queue job continues and sets it almost immediately back to false. In effect, this leaves the URLs to access these content review files open for anyone to access once more, as there is no authentication performed on these requests.

The solution to this, is marking the urlAccessed column as insert=true and update=false in the Hibernate mapping XML file. In this way, when creating a new contentReviewItem, the urlAccessed parameter will default to false, and any code updating this object via the DAO will reject any changes to this column.

Then, in the one and only place we want to set the urlAccessed value to true (after TII has called us back and retrieved the file), we call a method that runs some custom HQL to manually update the value to true for the given row.

We've also added some extra obfuscation to these URLs because they are not authenticated. Currently, the URL could technically be determined by an attacker (with a combination of sleuthing/inspecting elements and brute force), as it contains the site ID, the submission ID, and the (positive, sequential integer) ID of the content review item.

The extra protection we've implemented, is by appending the hash value of the contentId to the access URL. Due to the fact that the content ID is a combination of two additional, non-user facing UUIDs and the actual file name and extension of the file in question, it is near impossible for an attacker to determine this string and it's subsequent hash code. When the URL is accessed, it will first check to see that the hash codes match, and short circuit if not.

Lastly, we've modified the conditional logic around actually serving up the file. Previously, the file was only served if and only if the isUrlAccessed property was false. However, due to the calls to and from TII being asynchronous, we cannot safely assume that the status of the item will be either 1 or 2 by the time TII attempts to retrieve the file. Depending on timing, it could very well be one or the other (coupled with the fact that we've seen TII make multiple requests to get the same file), and we need to allow TII to get the file in both of these circumstances.

Therefore, we've determined that the file should be served in only the following circumstances:
- if the URL has not yet been accessed
- if the URL has been accessed, but the status is one of the following: 1 (not yet submitted), 2 (submitted, waiting for report), and 4 (submission error, will retry)

Of course, the hashing protection and validation happens prior to checking these conditions, serving as both another layer of obfuscation as well as a short circuit for the process.
