### PR TITLE
TII-202 remove Google Docs from accepted file types for TII

### DIFF
--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinReviewServiceImpl.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinReviewServiceImpl.java
@@ -170,10 +170,7 @@ public class TurnitinReviewServiceImpl extends BaseReviewServiceImpl {
 		".rtf", 
 		".rtf", 
 		".rtf", 
-		".hwp", 
-		".gdoc", 
-		".gslide", 
-		".gsheet"
+		".hwp"
 	};
 	private final String[] DEFAULT_ACCEPTABLE_MIME_TYPES = new String[] {
 		"application/msword", 
@@ -204,10 +201,7 @@ public class TurnitinReviewServiceImpl extends BaseReviewServiceImpl {
 		"application/rtf", 
 		"application/x-rtf", 
 		"text/richtext", 
-		"application/x-hwp", 
-		"application/vnd.google-apps.document", 
-		"application/vnd.google-apps.presentation", 
-		"application/vnd.google-apps.spreadsheet"
+		"application/x-hwp"
 	};
 
 	// Sakai.properties overriding the arrays above

--- a/contentreview-impl/impl/src/java/turnitin.properties
+++ b/contentreview-impl/impl/src/java/turnitin.properties
@@ -29,6 +29,3 @@ file.type.wpd = WordPerfect
 file.type.odt = OpenOffice
 file.type.rtf = rich text
 file.type.hwp = Hangul
-file.type.gdoc = Google Doc
-file.type.gslide = Google Slide
-file.type.gsheet = Google Sheet


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/TII-202

Didn't see this in the documentation:

"Google Docs via Google Drive™
Note: If submitting with Google Drive™, third party cookies must be allowed in your browser, otherwise, any attempts to sign into Google to upload from Google Drive will fail. Note that Google Drive functionality is not supported with IE8 or below. Do not upload Google Doc (.gdoc) files directly to Turnitin; a .gdoc file does not store the document, but contains a reference to it online, in Google Docs"
