### PR TITLE
TII-204 Prevent concurrent modification exception.

### DIFF
--- a/contentreview-impl/impl/src/java/org/sakaiproject/turnitin/util/TurnitinLTIUtil.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/turnitin/util/TurnitinLTIUtil.java
@@ -180,7 +180,7 @@ public class TurnitinLTIUtil {
 			}
 		
 		} catch (Exception e) {
-			log.error("Exception while making TII LTI call " + e.getMessage());
+			log.error("Exception while making TII LTI call " + e.getMessage(), e);
 			return -4;
 	    }
 		
@@ -304,13 +304,14 @@ public class TurnitinLTIUtil {
 		return null;
 	}
 
-	private Map<String, String> cleanUpProperties(Map<String, String> rawProperties) {
-		for (String okey : rawProperties.keySet()) {
+	Map<String, String> cleanUpProperties(Map<String, String> rawProperties) {
+		for (Iterator<String> iterator = rawProperties.keySet().iterator(); iterator.hasNext(); ) {
+			String okey = iterator.next();
 			String key = okey.trim();
 			String value = rawProperties.get(key);
 			if (value == null || "".equals(value)) {
 				// remove null or empty values
-				rawProperties.remove(key);
+				iterator.remove();
 			}
 		}
 		return rawProperties;

--- a/contentreview-impl/impl/src/test/org/sakaiproject/turnitin/util/TurnitinLTIUtilTest.java
+++ b/contentreview-impl/impl/src/test/org/sakaiproject/turnitin/util/TurnitinLTIUtilTest.java
@@ -1,0 +1,46 @@
+package org.sakaiproject.turnitin.util;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TurnitinLTIUtilTest {
+
+    private TurnitinLTIUtil util;
+
+    @Before
+    public void setUp() {
+        this.util = new TurnitinLTIUtil();
+    }
+
+    @Test
+    public void testCleanupPropertiesEmpty() {
+        Map<String, String> empty = Collections.emptyMap();
+        Map<String, String> cleaned = util.cleanUpProperties(empty);
+        Assert.assertEquals(empty, cleaned);
+    }
+
+    @Test
+    public void testCleanupPropertiesNoRemove() {
+        Map<String, String> good = new HashMap<>();
+        good.put("key1", "value1");
+        good.put("key2", "value2");
+        Map<String, String> cleaned = util.cleanUpProperties(good);
+        Assert.assertEquals(good, cleaned);
+    }
+
+    @Test
+    public void testCleanupPropertiesRemove() {
+        Map<String, String> bad = new HashMap<>();
+        bad.put("key1", "");
+        bad.put("key2", null);
+        Map<String, String> cleaned = util.cleanUpProperties(bad);
+        Assert.assertEquals(Collections.emptyMap(), cleaned);
+    }
+
+
+}


### PR DESCRIPTION
When attempting to cleanup the properties sent over the TII the code would attempt to modify a collection it was iterating over resulting in a concurrent modification exception.

```
This also adds logging to the Exception handling so that catching bugs like this in the future is quicker.
```
