### PR TITLE
TII-209 Work when site updated outside portal.

### DIFF
--- a/contentreview-impl/pack/src/webapp/WEB-INF/components.xml
+++ b/contentreview-impl/pack/src/webapp/WEB-INF/components.xml
@@ -225,7 +225,7 @@
     <property name="eventTrackingService" ref="org.sakaiproject.event.api.EventTrackingService" />
     <property name="turnitinRosterSync" ref="org.sakaiproject.contentreview.impl.turnitin.TurnitinRosterSync" />
     <property name="dao" ref="org.sakaiproject.contentreview.dao.ContentReviewDao" />
-    <property name="siteService" ref="org.sakaiproject.site.api.SiteService" />
+    <property name="entityManager" ref="org.sakaiproject.entity.api.EntityManager" />
     <property name="contentReviewService" ref="org.sakaiproject.contentreview.service.ContentReviewServiceTii" />
 	<property name="contentReviewSiteAdvisor" ref="org.sakaiproject.contentreview.service.ContentReviewSiteAdvisor" />	
    </bean>


### PR DESCRIPTION
If a site is updated outside the portal then there isn’t a context set on the event that is generated so the turnitin code wouldn’t know which site had been updated.
