### PR TITLE
TII-214 Improve error logging in logs and database

### DIFF
--- a/contentreview-impl/impl/src/java/org/sakaiproject/turnitin/util/TurnitinLTIUtil.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/turnitin/util/TurnitinLTIUtil.java
@@ -212,7 +212,7 @@ public class TurnitinLTIUtil implements TurnitinLTIAPI {
 				log.debug(method.getResponseBodyAsString());
 			}
 		
-		} catch (IllegalArgumentException | IOException | JSONException e) {
+		} catch (Exception e) {
 			log.error("Exception while making TII LTI call " + e.getMessage(), e);
 			retVal.setResult( -4 );
 			retVal.setErrorMessage( "Exception while making TII LTI call " + e.getMessage() );
@@ -382,6 +382,9 @@ public class TurnitinLTIUtil implements TurnitinLTIAPI {
 		} catch(ParserConfigurationException | SAXException | IOException | DOMException ee){
 			log.error("Could not parse TII response: " + ee.getMessage());
 			return ee.getMessage();
+		} catch(Exception e){
+			log.error( "Unexpected exception parsing XML response", e );
+			return e.getMessage();
 		}
 		return null;
 	}

--- a/contentreview-impl/impl/src/java/org/sakaiproject/turnitin/util/TurnitinReturnValue.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/turnitin/util/TurnitinReturnValue.java
@@ -1,0 +1,39 @@
+/**********************************************************************************
+ * $URL: 
+ * $Id: 
+ ***********************************************************************************
+ *
+ * Copyright (c) 2006 Sakai Foundation
+ *
+ * Licensed under the Educational Community License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.osedu.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **********************************************************************************/
+package org.sakaiproject.turnitin.util;
+
+/**
+ * Custom class to represent return values from TII, containing an integer indicating the result
+ * and an error message if an error occurred.
+ */
+public class TurnitinReturnValue
+{
+    private int result;
+    private String errorMessage;
+
+    public TurnitinReturnValue() {}
+
+    public int getResult() { return result; }
+    public String getErrorMessage() { return errorMessage; }
+
+    public void setResult( int result ) { this.result = result; }
+    public void setErrorMessage( String errorMessage ) { this.errorMessage = errorMessage; }
+}

--- a/contentreview-impl/impl/src/test/org/sakaiproject/contentreview/mocks/FakeTiiUtil.java
+++ b/contentreview-impl/impl/src/test/org/sakaiproject/contentreview/mocks/FakeTiiUtil.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.sakaiproject.turnitin.util.TurnitinLTIUtil;
+import org.sakaiproject.turnitin.util.TurnitinReturnValue;
 
 public class FakeTiiUtil extends TurnitinLTIUtil{
 	
@@ -11,8 +12,10 @@ public class FakeTiiUtil extends TurnitinLTIUtil{
 		return "globalId";
 	}
 	
-	public int makeLTIcall(int type, String urlParam, Map<String, String> ltiProps){
-		return 1;//TODO checks o algo?
+	public TurnitinReturnValue makeLTIcall(int type, String urlParam, Map<String, String> ltiProps){
+		TurnitinReturnValue retVal = new TurnitinReturnValue();
+		retVal.setResult( 1 );
+		return retVal;
 	}
 	
 	public Object insertTIIToolContent(String globalToolId, Properties props){


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/TII-214

Currently we get only the request status code (ie, "400 Bad Request") in the lastError column for failed LTI submissions, etc. The only way to get more information out of this, is to bump your logger level way up to debug, or run your server in debug mode and step through the code to get more info out of the XML response.

This can be improved by refactoring the way the return logic and error handling is performed. In effect, we can get the reason from the XML response and put this into the lastError column in the database, as well as improve what information is logged at ERROR and WARN levels.
