### PR TITLE
TII-215 expose the lastError value from TII in the UI (conditionally)

### DIFF
--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinReviewServiceImpl.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinReviewServiceImpl.java
@@ -2050,7 +2050,7 @@ public class TurnitinReviewServiceImpl extends BaseReviewServiceImpl {
 					String returnedError = ltiProps.get("returnedError");
 					if( returnedError == null )
 					{
-						returnedError = "LTI Submission Error: " + returnedError;
+						returnedError = "Submission Error: " + returnedError;
 					}
 					log.warn("LTI submission error");
 					processError( currentItem, ContentReviewItem.SUBMISSION_ERROR_RETRY_CODE, returnedError, null );
@@ -2486,7 +2486,7 @@ public class TurnitinReviewServiceImpl extends BaseReviewServiceImpl {
 						currentItem.setRetryCount(l);
 						currentItem.setNextRetryTime(this.getNextRetryTime(l));
 						currentItem.setStatus(ContentReviewItem.REPORT_ERROR_RETRY_CODE);
-						currentItem.setLastError("LTI Report Data Error: " + result.getResult());
+						currentItem.setLastError("Report Data Error: " + result.getResult());
 					}
 					dao.update(currentItem);
 				}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/TII-215

Currently we have generic messages for the user based on status. So a status 4 submission, regardless of the failure reason, will say "An error occured submitted this attachment to the originality checking service. The system will automatically try to re-submit this attachment."

It would be beneficial to add the details from Turnitin to the message. In this way, the instructor, student and/or support person would be better able to tell if the submission will eventually go through or not. "File contained no valid text" is a pretty good indication that you're not getting a report back. This is just one example.

Exposing this to the UI is controlled by a sakai.property (turnitin.exposeErrorToUI) which defaults to false. If the property is set to true, the errors are only exposed in the case where the status is 4 or 5 (submission error will retry, or submission error will not retry).
