### PR TITLE
TII-217 SQL statement for TII-201 does not work for case sensitive MySQL instances

### DIFF
--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/dao/impl/ContentReviewDaoImpl.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/dao/impl/ContentReviewDaoImpl.java
@@ -43,7 +43,7 @@ public class ContentReviewDaoImpl
 
 	private static final Log log = LogFactory.getLog(ContentReviewDaoImpl.class);
 
-	private static final String SQL_UPDATE_IS_URL_ACCESSED = "UPDATE contentreview_item SET urlAccessed = :isUrlAccessed WHERE contentId = :contentID";
+	private static final String SQL_UPDATE_IS_URL_ACCESSED = "UPDATE CONTENTREVIEW_ITEM SET URLACCESSED = :isUrlAccessed WHERE CONTENTID = :contentID";
 
 	public void init() {
 		log.debug("init");


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/TII-217

The SQL statement references table and column names in lower case, which does not work for case sensitive MySQL installs.

Changing the table and column names to upper case will fix the issue while still maintaining compatibility for non-case sensitive MySQL instances as well as Oracle instances.
