### PR TITLE
TII-180 roster sync logs deleted users at warn level

### DIFF
--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinRosterSync.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinRosterSync.java
@@ -336,7 +336,7 @@ public class TurnitinRosterSync {
 		try {
 			user = userDirectoryService.getUser(userid);
 		} catch (UserNotDefinedException e) {
-			log.warn("Attemping to lookup user for Turnitn Sync that does not exist: " + userid, e);
+			log.debug("Attemping to lookup user for Turnitn Sync that does not exist: " + userid, e);
 		}
 		return user;
 	}


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/TII-180

In syncSiteWithTurnitin, we get the enrollment document from TII, and then we invoke swapTurnitinRoles(sakaiSiteId, getUser(uid), 2) for all TII instructors who don't have section.role.instructor. This includes instructors who have been deleted from Sakai. So getUser(uid) is invoked, which logs that they do not exist at warn level.

This should be reduced to debug as this information is useless 99% of the time (Ie. the user is deleted, so what can an administrator do about it?).

It may be good to report back to Turnitin that the user is deleted so they can remove the user from the enrollments on their end, but this may be something to consider in a separate ticket (or in the new TII integration perhaps)
