### PR TITLE
TII-223: Add cutover date feature to globalpropertyadvisor to aid with transitioning between legacy and LTI integrations

### DIFF
--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/advisors/ChainedPropertyAdvisor.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/advisors/ChainedPropertyAdvisor.java
@@ -1,5 +1,6 @@
 package org.sakaiproject.contentreview.impl.advisors;
 
+import java.util.Date;
 import org.sakaiproject.contentreview.service.ContentReviewSiteAdvisor;
 import org.sakaiproject.site.api.Site;
 
@@ -31,6 +32,16 @@ public class ChainedPropertyAdvisor implements ContentReviewSiteAdvisor {
     public boolean siteCanUseLTIReviewService(Site site) {
         for(ContentReviewSiteAdvisor advisor: advisors) {
             if (advisor.siteCanUseLTIReviewService(site)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean siteCanUseLTIReviewServiceForAssignment(Site site, Date asnCreationDate) {
+        for(ContentReviewSiteAdvisor advisor: advisors) {
+            if (advisor.siteCanUseLTIReviewServiceForAssignment(site, asnCreationDate)) {
                 return true;
             }
         }

--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/advisors/DefaultSiteAdvisor.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/advisors/DefaultSiteAdvisor.java
@@ -20,6 +20,7 @@
  **********************************************************************************/
 package org.sakaiproject.contentreview.impl.advisors;
 
+import java.util.Date;
 import org.sakaiproject.contentreview.service.ContentReviewSiteAdvisor;
 import org.sakaiproject.site.api.Site;
 
@@ -30,6 +31,12 @@ public class DefaultSiteAdvisor implements ContentReviewSiteAdvisor {
 	}
 	
 	public boolean siteCanUseLTIReviewService(Site site) {
+		return true;
+	}
+	
+	@Override
+	public boolean siteCanUseLTIReviewServiceForAssignment(Site site, Date assignmentCreationDate)
+	{
 		return true;
 	}
 	

--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/advisors/SiteCourseTypeAdvisor.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/advisors/SiteCourseTypeAdvisor.java
@@ -20,6 +20,7 @@
  **********************************************************************************/
 package org.sakaiproject.contentreview.impl.advisors;
 
+import java.util.Date;
 import org.sakaiproject.contentreview.service.ContentReviewSiteAdvisor;
 import org.sakaiproject.site.api.Site;
 
@@ -45,6 +46,12 @@ public class SiteCourseTypeAdvisor implements ContentReviewSiteAdvisor {
 		}
 		return false;
 		
+	}
+	
+	@Override
+	public boolean siteCanUseLTIReviewServiceForAssignment(Site site, Date assignmentCreationDate)
+	{
+		return siteCanUseLTIReviewService(site);
 	}
 	
 	public boolean siteCanUseLTIDirectSubmission(Site site) {

--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/advisors/SitePropertyAdvisor.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/advisors/SitePropertyAdvisor.java
@@ -20,6 +20,7 @@
  **********************************************************************************/
 package org.sakaiproject.contentreview.impl.advisors;
 
+import java.util.Date;
 import org.sakaiproject.contentreview.service.ContentReviewSiteAdvisor;
 import org.sakaiproject.entity.api.ResourceProperties;
 import org.sakaiproject.site.api.Site;
@@ -51,6 +52,12 @@ public class SitePropertyAdvisor implements ContentReviewSiteAdvisor {
 		ResourceProperties properties = site.getProperties();		
 		String prop = properties.getProperty(siteLTIProperty);
 		return Boolean.valueOf(prop).booleanValue();
+	}
+	
+	@Override
+	public boolean siteCanUseLTIReviewServiceForAssignment(Site site, Date assignmentCreationDate)
+	{
+		return siteCanUseLTIReviewService(site);
 	}
 	
 	public boolean siteCanUseLTIDirectSubmission(Site site){

--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/MembershipChangeObserver.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/MembershipChangeObserver.java
@@ -100,7 +100,10 @@ public class MembershipChangeObserver implements Observer {
 				} else {
 					log.warn("Error observing Turnitin Membership update because we failed to find site: " + event.getResource());
 				}
-				if (site != null && contentReviewService.isSiteAcceptable(site) && !contentReviewSiteAdvisor.siteCanUseLTIReviewService(site)) {
+				// removing this canUseLTIReviewService check for now because due to the cutover date feature a site may have both types of integrations
+				// active and could still need roster sync
+				// this should be revisited once the TII legacy api ceases to function
+				if (site != null && contentReviewService.isSiteAcceptable(site) /*&& !contentReviewSiteAdvisor.siteCanUseLTIReviewService(site)*/) {
 					Restriction notFinished = new Restriction("status", ContentReviewRosterSyncItem.FINISHED_STATUS, Restriction.NOT_EQUALS);
 					Restriction siteIdEquals = new Restriction("siteId", event.getContext(), Restriction.EQUALS);
 					Search search = new Search(new Restriction[] {notFinished,siteIdEquals});

--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinRosterSync.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinRosterSync.java
@@ -384,9 +384,11 @@ public class TurnitinRosterSync {
 			return true;
 		}
 
-		if(contentReviewSiteAdvisor.siteCanUseLTIReviewService(site)){
+		// Removing this for now because due to the temporary cutover date feature a site may have both types of integration
+		// active and could still need roster sync
+		/*if(contentReviewSiteAdvisor.siteCanUseLTIReviewService(site)){
 			return false;
-		}
+		}*/
 		
 		Map<String, List<String>> enrollment = getInstructorsStudentsForSite(sakaiSiteID);
 

--- a/contentreview-impl/impl/src/test/org/sakaiproject/contentreview/logic/TurnitinImplTest.java
+++ b/contentreview-impl/impl/src/test/org/sakaiproject/contentreview/logic/TurnitinImplTest.java
@@ -44,6 +44,7 @@ import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
 import org.easymock.EasyMock;
 import static org.easymock.EasyMock.*;
 import static org.mockito.Mockito.*;
+import org.sakaiproject.contentreview.mocks.FakeTime;
 
  @ContextConfiguration(locations={
 		"/hibernate-test.xml",
@@ -134,12 +135,15 @@ public class TurnitinImplTest extends AbstractJUnit4SpringContextTests {
 		expect(M_ss.getSite("siteId")).andStubReturn(siteA);
 		replay(M_ss);
 		
+		Assignment assignA = createMock(Assignment.class);
+		expect(M_assi.getAssignment("taskId")).andStubReturn(assignA);
+		expect(assignA.getTimeCreated()).andStubReturn(new FakeTime());
 		ContentReviewSiteAdvisor siteAdvisor = createMock(ContentReviewSiteAdvisor.class);
-		expect(siteAdvisor.siteCanUseLTIReviewService(siteA)).andStubReturn(true);
+		expect(siteAdvisor.siteCanUseLTIReviewServiceForAssignment(siteA, new Date(0))).andStubReturn(true);
 		replay(siteAdvisor);
 		tiiService.setSiteAdvisor(siteAdvisor);
 		
-		Assignment assignA = createMock(Assignment.class);
+		
 		List l = new ArrayList();
 		l.add(assignA);
 		AssignmentContent contentA = createMock(AssignmentContent.class);
@@ -154,10 +158,13 @@ public class TurnitinImplTest extends AbstractJUnit4SpringContextTests {
 		expect(contentEdA.getPropertiesEdit()).andStubReturn(rpEdit);
 		replay(contentEdA);
 		expect(M_assi.getAssignments(contentA)).andStubReturn(l.iterator());
+		expect(assignA.getId()).andStubReturn("1234");
+		expect(assignA.getTitle()).andStubReturn("Asn1");
 		M_assi.commitEdit(contentEdA);
 		EasyMock.expectLastCall();
 		expect(M_assi.getSubmissions(assignA)).andStubReturn(null);
 		replay(M_assi);
+		replay(assignA);
 		
 		TurnitinAccountConnection tac = new TurnitinAccountConnection();
 		tac.setUseSourceParameter(false);
@@ -241,14 +248,16 @@ public class TurnitinImplTest extends AbstractJUnit4SpringContextTests {
 		replay(r);
 		replay(rp);
 		
+		M_assi = createMock(AssignmentService.class);
+		org.sakaiproject.assignment.api.Assignment assignA = createMock(org.sakaiproject.assignment.api.Assignment.class);
+		expect(assignA.getTimeCreated()).andStubReturn(new FakeTime());
+		expect(M_assi.getAssignment("taskId")).andStubReturn(assignA);
 		ContentReviewSiteAdvisor siteAdvisor = createMock(ContentReviewSiteAdvisor.class);
-		expect(siteAdvisor.siteCanUseLTIReviewService(siteA)).andStubReturn(true);
+		expect(siteAdvisor.siteCanUseLTIReviewServiceForAssignment(siteA, new Date(0))).andStubReturn(true);
 		replay(siteAdvisor);
 		tiiService.setSiteAdvisor(siteAdvisor);
 		
-		M_assi = createMock(AssignmentService.class);
 		tiiService.setAssignmentService(M_assi);
-		org.sakaiproject.assignment.api.Assignment assignA = createMock(org.sakaiproject.assignment.api.Assignment.class);
 		expect(M_assi.getAssignment("taskId")).andStubReturn(assignA);
 		expect(M_assi.getAssignment("task")).andStubReturn(assignA);//from dao test
 		AssignmentContent contentA = createMock(AssignmentContent.class);

--- a/contentreview-impl/impl/src/test/org/sakaiproject/contentreview/mocks/FakeTime.java
+++ b/contentreview-impl/impl/src/test/org/sakaiproject/contentreview/mocks/FakeTime.java
@@ -1,0 +1,57 @@
+package org.sakaiproject.contentreview.mocks;
+
+import org.sakaiproject.time.api.Time;
+import org.sakaiproject.time.api.TimeBreakdown;
+
+public class FakeTime implements Time
+{
+	public String toStringSql()	{ return null; }
+
+	public String toStringLocal() 	{ return null; }
+
+	public String toStringGmtFull() { return null; }
+
+	public String toStringLocalFull(){ return null; }
+
+	public String toStringLocalFullZ(){ return null; }
+
+	public String toStringGmtShort(){ return null; }
+
+	public String toStringLocalShort(){ return null; }
+
+	public String toStringGmtTime(){ return null; }
+
+	public String toStringLocalTime(){ return null; }
+
+	public String toStringLocalTime24(){ return null; }
+
+	public String toStringLocalTimeZ(){ return null; }
+
+	public String toStringGmtDate(){ return null; }
+
+	public String toStringLocalDate(){ return null; }
+
+	public String toStringLocalShortDate(){ return null; }
+
+	public String toStringRFC822Local(){ return null; }
+
+	public String toStringFilePath(){ return null; }
+
+	public void setTime(long l){ return; }
+
+	public long getTime(){ return 0; }
+
+	public boolean before(Time time){ return true; }
+
+	public boolean after(Time time){ return true; }
+
+	public Object clone(){ return null; }
+
+	public TimeBreakdown breakdownGmt(){ return null; }
+
+	public TimeBreakdown breakdownLocal(){ return null; }
+
+	public String getDisplay(){ return null; }
+	
+	public int compareTo(Object o) { return 0; }
+}

--- a/contentreview-impl/pack/src/webapp/WEB-INF/components.xml
+++ b/contentreview-impl/pack/src/webapp/WEB-INF/components.xml
@@ -63,11 +63,11 @@
 
 	<!--  Uncomment this to use a site property to define which sites use c-r -->
 	
-	<bean id="org.sakaiproject.contentreview.service.ContentReviewSiteAdvisor" class="org.sakaiproject.contentreview.impl.advisors.SitePropertyAdvisor">
+	<!--<bean id="org.sakaiproject.contentreview.service.ContentReviewSiteAdvisor" class="org.sakaiproject.contentreview.impl.advisors.SitePropertyAdvisor">
 		<property name="siteProperty"><value>useContentReviewService</value></property>
 		<property name="siteLTIProperty"><value>useContentReviewLTIService</value></property>
 		<property name="siteDirectSubmissionProperty"><value>useContentReviewDirectSubmission</value></property>
-	</bean>
+	</bean>-->
 	
 	<!-- uncomment this bean to make cr available to only sites of the type course -->
 	<!--
@@ -76,13 +76,14 @@
 	-->
 	
 	<!--  Uncomment this to use a global property to define if every site uses c-r -->
-	<!--<bean id="org.sakaiproject.contentreview.service.ContentReviewSiteAdvisor" class="org.sakaiproject.contentreview.impl.advisors.GlobalPropertyAdvisor">
+	<bean id="org.sakaiproject.contentreview.service.ContentReviewSiteAdvisor" class="org.sakaiproject.contentreview.impl.advisors.GlobalPropertyAdvisor">
 		<property name="tiiProperty"><value>assignment.useContentReview</value></property>
 		<property name="tiiLTIProperty"><value>assignment.useContentReviewLTI</value></property>
 		<property name="tiiDirectSubmissionProperty"><value>assignment.useContentReviewDirect</value></property>
+		<property name="tiiLTICutoverDateProperty"><value>assignment.useContentReviewLTICutoverDate</value></property>
 		<property name="serverConfigurationService"
 			ref="org.sakaiproject.component.api.ServerConfigurationService" />
-	</bean>-->
+	</bean>
 
 	<!-- uncomment this bean to make cr available using chained advisors -->
 	<!--


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/TII-223

At Western we have developed and deployed a simple way to transition over to the LTI integration. By adding a cutover date property to the global site advisor and setting the date to match that of our deployment, we have a system where any Turnitin assignments created prior to the deployment will continue to use the legacy integration, while all newly created assignments will use the LTI integration. This also allows a site to use both types of integration at the same time. A single point-in-time cutover can easily be communicated to instructors and does not require any intervention by system administrators.

This patch provides this implementation, along with making the globalpropertyadvisor the default content review site advisor.

The cutover date property is:

assignment.useContentReviewLTICutoverDate=2016-SEP-02

The date format must match the example above (yyyy-MMM-dd). If the property is not set or is set incorrectly, behaviour falls back to the original globalpropertyadvisor logic.
