### PR TITLE
TII-222 - added content review service configuration to accept multiple attachments

### DIFF
--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinReviewServiceImpl.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinReviewServiceImpl.java
@@ -414,6 +414,11 @@ public class TurnitinReviewServiceImpl extends BaseReviewServiceImpl {
 		return siteAdvisor != null && siteAdvisor.siteCanUseReviewService(s) && siteAdvisor.siteCanUseLTIReviewService(s) && siteAdvisor.siteCanUseLTIDirectSubmission(s);
 	}
 
+	public boolean allowMultipleAttachments()
+	{
+		return serverConfigurationService.getBoolean("turnitin.allow.multiple.attachments", false);
+	}
+
 
 	public String getIconUrlforScore(Long score) {
 


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/TII-222

Originality reports for submissions with multiple attachments was supported in the Sakai API integration. We should continue to support this functionality.

Introduces sakai.property "turnitin.allow.mutliple.attachments"; default is false.
