### PR TITLE
TII-228 - originality report icons will link users directly to their associated originality reports on the TII website

### DIFF
--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinReviewServiceImpl.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinReviewServiceImpl.java
@@ -590,7 +590,7 @@ public class TurnitinReviewServiceImpl extends BaseReviewServiceImpl {
 			throw new ReportException("Report not available: " + item.getStatus());
 		}
 		
-		return getLTIAccess(item.getTaskId(), item.getSiteId());
+		return getLTIReportAccess(item);
 	}
 
     /**
@@ -1193,6 +1193,7 @@ public class TurnitinReviewServiceImpl extends BaseReviewServiceImpl {
 			//check if it was already created
 			String tiiId;
 			String ltiId = null;
+			String ltiReportsId = null;
 			try {
 				AssignmentContent ac = assignmentService.getAssignmentContent(taskId);
 				ResourceProperties aProperties = ac.getProperties();
@@ -1200,6 +1201,8 @@ public class TurnitinReviewServiceImpl extends BaseReviewServiceImpl {
 				log.debug("This assignment has associated the following TII id: " + tiiId);				
 				ltiId = aProperties.getProperty("lti_id");
 				log.debug("This assignment has associated the following LTI id: " + ltiId);
+				ltiReportsId = s.getProperties().getProperty("turnitin_reports_lti_id");
+				log.debug("This assignment has associated the following LTI id: " + ltiReportsId);
 			} catch (Exception e) {
 				log.debug("New TII assignment: " + taskId);
 			}
@@ -1324,11 +1327,14 @@ public class TurnitinReviewServiceImpl extends BaseReviewServiceImpl {
 			
 			Properties sakaiProps = new Properties();
 			String globalId = tiiUtil.getGlobalTurnitinLTIToolId();
+			String globalReportsId = tiiUtil.getGlobalTurnitinReportsLTIToolId();
 			if(globalId == null){
 				throw new TransientSubmissionException("Create Assignment not successful. TII LTI global id not set");
 			}
+			if (globalReportsId == null){
+				throw new TransientSubmissionException("Create Assignment not successful. TII Reports LTI global id not set");
+			}
 
-			sakaiProps.setProperty(LTIService.LTI_TOOL_ID,globalId);				
 			sakaiProps.setProperty(LTIService.LTI_SITE_ID,siteId);
 			sakaiProps.setProperty(LTIService.LTI_TITLE,title);
 
@@ -1337,13 +1343,25 @@ public class TurnitinReviewServiceImpl extends BaseReviewServiceImpl {
 
 			SecurityAdvisor advisor = new SimpleSecurityAdvisor(sessionManager.getCurrentSessionUserId(), "site.upd", "/site/!admin");
 			Object ltiContent = null;
+			Object ltiReportsContent = null;
 			try{
 				securityService.pushAdvisor(advisor);
+				sakaiProps.setProperty(LTIService.LTI_TOOL_ID, globalId);
 				if(ltiId == null){
 					ltiContent = tiiUtil.insertTIIToolContent(globalId, sakaiProps);
 				} else {//don't create lti tool if exists
 					ltiContent = tiiUtil.updateTIIToolContent(ltiId, sakaiProps);
 				}				
+				// replace the property
+				sakaiProps.setProperty(LTIService.LTI_TOOL_ID, globalReportsId);
+				if (ltiReportsId == null)
+				{
+					ltiReportsContent = tiiUtil.insertTIIToolContent(globalReportsId, sakaiProps);
+				}
+				else
+				{
+					ltiReportsContent = tiiUtil.updateTIIToolContent(ltiReportsId, sakaiProps);
+				}
 			} catch(Exception e){
 				throw new TransientSubmissionException("Create Assignment not successful. Error trying to insert TII tool content: " + e.getMessage());
 			} finally {
@@ -1352,18 +1370,35 @@ public class TurnitinReviewServiceImpl extends BaseReviewServiceImpl {
 				
 			if(ltiContent == null){
 				throw new TransientSubmissionException("Create Assignment not successful. Could not create LTI tool for the task: " + custom);
-			} else if(ltiId != null){
-				if(ltiContent instanceof String){
-					throw new TransientSubmissionException("Update Assignment not successful. Error updating LTI stealthed tool: " + ltiId);
-				}//boolean if everything went fine
-			} else if(!(ltiContent instanceof Long)){
+			} else if (ltiReportsContent == null){
+				throw new TransientSubmissionException("Create Assignment not successful. Could not create LTI Reports tool for the task: " + custom);
+			} else if (ltiId != null && !Boolean.TRUE.equals(ltiContent)){
+				// if ltiId != null, the lti already exists, so we did an update. ltiContent is Boolean.TRUE if the update was successful
+				throw new TransientSubmissionException("Update Assignment not successful. Error updating LTI stealthed tool: " + ltiId);
+			} else if (ltiReportsId != null && !Boolean.TRUE.equals(ltiReportsContent)){
+				throw new TransientSubmissionException("Update Assignment not successful. Error updating LTI reports stealthed tool: " + ltiReportsContent);
+			} else if (ltiId == null && !(ltiContent instanceof Long)){
+				// if ltiId == null, the lti is new, so we did an insert. ltiContent is a Long primary key if the update was successful
 				throw new TransientSubmissionException("Create Assignment not successful. Error creating LTI stealthed tool: " + ltiContent);
-			} else {//long if everything went fine
+			} else if (ltiReportsId == null && !(ltiReportsContent instanceof Long)){
+				throw new TransientSubmissionException("Create Assignment not successful. Error creating LTI stealthed tool: " + ltiReportsContent);
+			}
+			if (ltiId == null || ltiReportsId == null) {//we inserted, need to record the IDs
 				log.debug("LTI content tool id: " + ltiContent);
 				try{
 					AssignmentContentEdit ace = assignmentService.editAssignmentContent(taskId);
 					ResourcePropertiesEdit aPropertiesEdit = ace.getPropertiesEdit();
-					aPropertiesEdit.addProperty("lti_id", String.valueOf(ltiContent));
+					if (ltiId == null)
+					{
+						// new lti instance; record the ID from ltiContent
+						aPropertiesEdit.addProperty("lti_id", String.valueOf(ltiContent));
+					}
+					if (ltiReportsId == null)
+					{
+						ResourcePropertiesEdit rpe = s.getPropertiesEdit();
+						rpe.addProperty("turnitin_reports_lti_id", String.valueOf(ltiReportsContent));
+						siteService.save(s);
+					}
 					assignmentService.commitEdit(ace);
 				}catch(Exception e){
 					log.error("Could not store LTI tool ID " + ltiContent +" for assignment " + taskId);
@@ -3370,17 +3405,44 @@ public class TurnitinReviewServiceImpl extends BaseReviewServiceImpl {
 		}
 		return ltiUrl;
 	}
+
+	public String getLTIReportAccess(ContentReviewItem item)
+	{
+		String ltiReportsUrl = null;
+		String contentId = item.getContentId();
+		String assignmentId = item.getTaskId();
+		String siteId = item.getSiteId();
+		try
+		{
+			String ltiReportsId = siteService.getSite(siteId).getProperties().getProperty("turnitin_reports_lti_id");
+			ContentResource resource = null;
+			resource = contentHostingService.getResource(contentId);
+			ResourceProperties resourceProperties = resource.getProperties();
+			String ltiResourceId = resourceProperties.getProperty("turnitin_id");
+			if (ltiResourceId == null)
+			{
+				// Fallback: link to assignment
+				return getLTIAccess(assignmentId, siteId);
+			}
+			ltiReportsUrl = "/access/basiclti/site/" + siteId + "/content:" + ltiReportsId + ",resource:" + ltiResourceId;
+			log.debug("getLTIRepotAccess: " + ltiReportsUrl);
+		}
+		catch (Exception e)
+		{
+			log.warn("Exception while trying to get LTI Reports access for assignment "  + assignmentId + ", resource " + contentId + ", and site " + siteId + ": " + e.getMessage());
+		}
+		return ltiReportsUrl;
+	}
 	
 	public boolean deleteLTITool(String taskId, String contextId){
 		SecurityAdvisor advisor = new SimpleSecurityAdvisor(sessionManager.getCurrentSessionUserId(), "site.upd", "/site/!admin");
-		boolean deleted = false;
 		try{
 			org.sakaiproject.assignment.api.Assignment a = assignmentService.getAssignment(taskId);
 			AssignmentContent ac = a.getContent();
 			ResourceProperties aProperties = ac.getProperties();
 			String ltiId = aProperties.getProperty("lti_id");
 			securityService.pushAdvisor(advisor);
-			deleted = tiiUtil.deleteTIIToolContent(ltiId);
+			return tiiUtil.deleteTIIToolContent(ltiId);
 		} catch(IdUnusedException | PermissionException e){
 			log.warn("Error trying to delete TII tool content: " + e.getMessage());
 		} catch(Exception e) {
@@ -3388,7 +3450,7 @@ public class TurnitinReviewServiceImpl extends BaseReviewServiceImpl {
 		} finally {
 			securityService.popAdvisor(advisor);
 		}
-		return deleted;
+		return false;
 	}
 	
 	private List<ContentResource> getAllAcceptableAttachments(AssignmentSubmission sub, boolean allowAnyFile){

--- a/contentreview-impl/impl/src/java/org/sakaiproject/turnitin/util/TurnitinLTIUtil.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/turnitin/util/TurnitinLTIUtil.java
@@ -63,8 +63,10 @@ public class TurnitinLTIUtil implements TurnitinLTIAPI {
 	private String aid = null;
 	private String secret = null;
 	private String globalId = null;
+	private String globalReportsId = null;
 	private String endpoint = null;
 	private String turnitinSite = null;
+	private String turnitinReportsSite = null;
 	
 	private static final String SUCCESS_TEXT = "fullsuccess";
 	
@@ -87,6 +89,11 @@ public class TurnitinLTIUtil implements TurnitinLTIAPI {
 		if(StringUtils.isEmpty(turnitinSite)){
 			log.error("Turnitin global site property does not exist or is wrongly configured.");
 		}
+		turnitinReportsSite = serverConfigurationService.getString("turnitin.reports.lti.site", "!turnitin_reports");
+		if (StringUtils.isEmpty(turnitinReportsSite)){
+			log.error("TurnitinReports global site property does not exist or is wrongly configured.");
+		}
+
 		endpoint = serverConfigurationService.getString("turnitin.ltiURL", "https://sandbox.turnitin.com/api/lti/1p0/");
 		if(StringUtils.isEmpty(endpoint)){
 			log.error("Turnitin LTI endpoint property does not exist or is wrongly configured.");
@@ -303,6 +310,23 @@ public class TurnitinLTIUtil implements TurnitinLTIAPI {
 		log.debug("Global tool id: " + globalId);
 		
 		return globalId;
+	}
+
+	public String getGlobalTurnitinReportsLTIToolId()
+	{
+		log.debug("Setting global TII Reports LTI tool Id");
+		List<Map<String, Object>> tools = ltiService.getToolsDao("lti_tools.site_id = '" + turnitinReportsSite + "'", null, 0, 0, turnitinReportsSite);
+		if (tools == null || tools.size() != 1)
+		{
+			log.warn(tools == null ? "No tools found" : "Found: " + tools.size());
+			log.error("getGlobalTurnitinReportsLTIToolId: wrong global TII LTI tool configured");
+			return null;
+		}
+		Map<String, Object> tool = tools.get(0);
+		globalReportsId = String.valueOf(tool.get(ltiService.LTI_ID));
+		log.debug("Global reports tool id: " + globalReportsId);
+
+		return globalReportsId;
 	}
 
 	public String getGlobalSecret() {

--- a/contentreview-impl/impl/src/test/org/sakaiproject/contentreview/logic/TurnitinImplTest.java
+++ b/contentreview-impl/impl/src/test/org/sakaiproject/contentreview/logic/TurnitinImplTest.java
@@ -100,7 +100,7 @@ public class TurnitinImplTest extends AbstractJUnit4SpringContextTests {
 
 		M_assi = createMock(AssignmentService.class);
 		tiiService.setAssignmentService(M_assi);
-		M_ss = createMock(SiteService.class);
+		M_ss = EasyMock.createNiceMock(SiteService.class);
 		tiiService.setSiteService(M_ss);
 		M_lti = createMock(LTIService.class);
 		M_util.setLtiService(M_lti);
@@ -129,6 +129,8 @@ public class TurnitinImplTest extends AbstractJUnit4SpringContextTests {
 		Site siteA = createMock(Site.class);
 		expect(siteA.getShortDescription()).andStubReturn("shortdesc");
 		expect(siteA.getTitle()).andStubReturn("sitetitle");
+		ResourcePropertiesEdit siteProps = createMock(ResourcePropertiesEdit.class);
+		expect(siteA.getPropertiesEdit()).andStubReturn(siteProps);
 		replay(siteA);
 		
 		expect(M_ss.getSite("siteId")).andStubReturn(siteA);

--- a/contentreview-impl/impl/src/test/org/sakaiproject/contentreview/mocks/FakeTiiUtil.java
+++ b/contentreview-impl/impl/src/test/org/sakaiproject/contentreview/mocks/FakeTiiUtil.java
@@ -11,6 +11,10 @@ public class FakeTiiUtil extends TurnitinLTIUtil{
 	public String getGlobalTurnitinLTIToolId(){
 		return "globalId";
 	}
+
+	public String getGlobalTurnitinReportsLTIToolId(){
+		return "globalReportsId";
+	}
 	
 	public TurnitinReturnValue makeLTIcall(int type, String urlParam, Map<String, String> ltiProps){
 		TurnitinReturnValue retVal = new TurnitinReturnValue();


### PR DESCRIPTION
Linking users directly to originality reports was a behavior that existed in Sakai10
Turnitin has endpoints to access papers directly:
https://sandbox.turnitin.com/api/lti/1p0/dv/report/
https://api.turnitin.com/api/lti/1p0/dv/report/
https://api.turnitinuk.com/api/lti/1p0/dv/report/ (guessing)

Make originality report icon links take users to these endpoints

Requires another LTI external tool set up similarly to !turnitin, except the "Site Id" is "!turnitin_reports", and the URL is one of the endpoints above.
If requested, I can rework the PRs to introduce a sakai property for this to fall back to the original behavior (always direct users to the landing page for the assignment); but it's my opinion that it's more appropriate to direct users to the originality report of the attachment that was clicked.

Introduces sakai.property:
turnitin.ltireports.site=!turnitin_reports (default)

If merged, the set up documentation should be updated to include instructions to create the !turnitin_reports lti instance in External Tools
