### PR TITLE
TII-221 - Move turnitin_id attributes on content_resource.binary_entity to contentreview_item.externalId

### DIFF
--- a/contentreview-impl/hbm/src/java/org/sakaiproject/contentreview/hbm/ContentReviewItem.hbm.xml
+++ b/contentreview-impl/hbm/src/java/org/sakaiproject/contentreview/hbm/ContentReviewItem.hbm.xml
@@ -16,7 +16,7 @@
 		<property name="userId" type="string" length="255" not-null="false" />
 		<property name="siteId" type="string" length="255" not-null="false" />
 		<property name="taskId" type="string" length="255" not-null="false" />
-		<property name="externalId" type="string" length="255" not-null="false" />
+		<property name="externalId" type="string" length="255" not-null="false" insert="true" update="false"/>
 		<property name="dateQueued" type="java.util.Date" not-null="false"/>
 		<property name="dateSubmitted" type="java.util.Date" not-null="false"/>
 		<property name="dateReportReceived" type="java.util.Date" not-null="false"/>

--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/dao/impl/ContentReviewDao.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/dao/impl/ContentReviewDao.java
@@ -68,4 +68,12 @@ public interface ContentReviewDao extends CompleteGenericDao {
 	    * @return whether the update was successful
 	    */
 	   public boolean updateIsUrlAccessed( String contentID, boolean isUrlAccessed );
+
+	   /**
+	    * Updates the externalId field of the contentreview_item with the specified contentId
+	    * @param contentId the contentId of the contentreview_item to be updated
+	    * @param externalId the ID supplied remotely by the content review service for this item
+	    * @return whether the update was successful
+	    */
+	   public boolean updateExternalId(String contentId, String externalId);
 }

--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/dao/impl/ContentReviewDaoImpl.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/dao/impl/ContentReviewDaoImpl.java
@@ -43,6 +43,8 @@ public class ContentReviewDaoImpl
 
 	private static final Log log = LogFactory.getLog(ContentReviewDaoImpl.class);
 
+	private static final String SQL_UPDATE_EXTERNAL_ID = "UPDATE CONTENTREVIEW_ITEM SET EXTERNALID = :externalId WHERE CONTENTID = :contentId";
+
 	private static final String SQL_UPDATE_IS_URL_ACCESSED = "UPDATE CONTENTREVIEW_ITEM SET URLACCESSED = :isUrlAccessed WHERE CONTENTID = :contentID";
 
 	public void init() {
@@ -211,6 +213,22 @@ public class ContentReviewDaoImpl
 	      } catch (Exception ex) {
 	         log.error("Could not cleanup the lock ("+lockId+") after failure: " + ex.getMessage(), ex);
 	      }
+	   }
+
+	   /**
+	    * {@inheritDoc}
+	    */
+	   public boolean updateExternalId(String contentId, String externalId)
+	   {
+	       Session session = getSessionFactory().openSession();
+	       Transaction tx = session.beginTransaction();
+	       SQLQuery query = session.createSQLQuery(SQL_UPDATE_EXTERNAL_ID);
+	       query.setParameter("externalId", externalId);
+	       query.setParameter("contentId", contentId);
+	       int result = query.executeUpdate();
+	       tx.commit();
+	       session.close();
+	       return result > 0;
 	   }
 	
 }

--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/hbm/BaseReviewServiceImpl.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/hbm/BaseReviewServiceImpl.java
@@ -383,6 +383,11 @@ public abstract class BaseReviewServiceImpl implements ContentReviewService {
 	public boolean updateItemAccess(String contentId){
 		return dao.updateIsUrlAccessed( contentId, true );
 	}
+
+	public boolean updateExternalId(String contentId, String externalId)
+	{
+		return dao.updateExternalId(contentId, externalId);
+	}
 		
 	public boolean updateExternalGrade(String contentId, String score){
 		ContentReviewItem cri = getFirstItemByContentId(contentId);

--- a/contentreview-impl/impl/src/test/org/sakaiproject/contentreview/logic/TurnitinImplTest.java
+++ b/contentreview-impl/impl/src/test/org/sakaiproject/contentreview/logic/TurnitinImplTest.java
@@ -249,8 +249,6 @@ public class TurnitinImplTest extends AbstractJUnit4SpringContextTests {
 		expect(r.getId()).andStubReturn("contentId");
 		expect(rp.getNamePropDisplayName()).andStubReturn("displayName");
 		expect(rp.getProperty("displayName")).andStubReturn("fileName");
-		expect(rp.getProperty("turnitin_id")).andStubReturn("123456");
-		expect(rp.getPropertyNames()).andStubReturn(Arrays.asList(new String[]{"displayName", "turnitin_id"}).iterator());
 		replay(M_con);
 		replay(r);
 		replay(rp);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/TII-221

Background:

1. When a student submits an assignment, contentreview_items are created for the attachments.
2. The Content Review Queue job posts these attachments to Turnitin, turnitin responds whether the post was successful.
3. An asynchronous callback from Turnitin then gives us the "externalId" (the ID of the submitted file on TII's end).
4. The reports job then uses the "externalId" to retrieve Turnitin's originality report

Currently step 3 sets the externalId in the content_resource table's binary_entity column. This table represents files on the file system. There already exists an externalId column in contentreview_item specifically for this purpose which we are now just leaving null.

We should move the externalId to contentreview_item as it is a content-review specific datum, and this will make externalIds more searchable.