### PR TITLE
TII-227 - Implement mechanism to determine LTI role (Instructor / Learner) based on asn.grade instead of site.upd

### DIFF
--- a/contentreview-impl/pack/src/webapp/WEB-INF/components.xml
+++ b/contentreview-impl/pack/src/webapp/WEB-INF/components.xml
@@ -269,6 +269,8 @@
 			class="org.sakaiproject.turnitin.util.TurnitinLTIUtil"
 			init-method="init">
 		<property name="ltiService" ref="org.sakaiproject.lti.api.LTIService" />
+		<property name="securityService" ref="org.sakaiproject.authz.api.SecurityService" />
 		<property name="serverConfigurationService" ref="org.sakaiproject.component.api.ServerConfigurationService" />
+		<property name="siteService" ref="org.sakaiproject.site.api.SiteService" />
 	</bean>
 </beans>


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/TII-227

By default, basiclti determines your role as follows:
isSuperUser() -> admin;
has site.upd ? Instructor : Learner
In the case of TII, your role should be Instructor iff you have asn.grade rather than site.upd. But we don't want to hard-code a TII integration specific check for asn.grade in basiclti. Keep this role-determining logic separated by adding a mechanism to register a new interface called 'LTIRoleAdvisor' into the LTIService which determines your LTI role, then keep the TII specific implementation in content-review-impl.