### PR TITLE
TII-245 - Turnitin due date should be latest of accept until / resubmission accept until

### DIFF
--- a/contentreview-impl/common/src/java/org/sakaiproject/contentreview/turnitin/TurnitinConstants.java
+++ b/contentreview-impl/common/src/java/org/sakaiproject/contentreview/turnitin/TurnitinConstants.java
@@ -10,4 +10,5 @@ public class TurnitinConstants
 	public static final String TURNITIN_ASN_ID = "turnitin_asn_id";
 	public static final int PROVIDER_ID = 1;
 	public static final String SAKAI_ASSIGNMENT_TOOL_ID = "sakai.assignment.grades";
+	public static final String TURNITIN_ASN_LATEST_INDIVIDUAL_EXTENSION_DATE = "turnitin_asn_latest_individual_extension_date";
 }

--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinReviewServiceImpl.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinReviewServiceImpl.java
@@ -1280,7 +1280,7 @@ public class TurnitinReviewServiceImpl extends BaseReviewServiceImpl {
 			ltiProps.put("resource_link_description", description);
 
 			// TII-245
-			if (!StringUtils.isEmpty(ltiId))
+			if (!StringUtils.isBlank(ltiId))
 			{
 				// This is an existing LTI instance, need to handle student extensions
 				handleIndividualExtension(extensionDate, taskId, extraAsnnOpts);
@@ -1757,7 +1757,7 @@ public class TurnitinReviewServiceImpl extends BaseReviewServiceImpl {
 		// We keep track of this in the activity config table to save us from querying every submission to find the latest extension.
 		// This comes at the cost that we can never move TII's due date earlier once we've granted an extension; we can only push it out
 		String strLatestExtensionDate = getActivityConfigValue(TurnitinConstants.TURNITIN_ASN_LATEST_INDIVIDUAL_EXTENSION_DATE, TurnitinConstants.SAKAI_ASSIGNMENT_TOOL_ID, taskId, TurnitinConstants.PROVIDER_ID);
-		if (extensionDate != null || !StringUtils.isEmpty(strLatestExtensionDate))
+		if (extensionDate != null || !StringUtils.isBlank(strLatestExtensionDate))
 		{
 			// The due date we're sending to TII (latest of accept until / resubmit accept until)
 			long timestampDue = (Long) extraAsnOpts.get("timestampDue");
@@ -1765,7 +1765,7 @@ public class TurnitinReviewServiceImpl extends BaseReviewServiceImpl {
 			{
 				// Find what's later: the new extension date or the latest existing extension date
 				long latestExtensionDate = 0;
-				if (!StringUtils.isEmpty(strLatestExtensionDate))
+				if (!StringUtils.isBlank(strLatestExtensionDate))
 				{
 					latestExtensionDate = Long.parseLong(strLatestExtensionDate);
 				}

--- a/contentreview-impl/impl/src/test/org/sakaiproject/contentreview/logic/TurnitinImplTest.java
+++ b/contentreview-impl/impl/src/test/org/sakaiproject/contentreview/logic/TurnitinImplTest.java
@@ -185,6 +185,7 @@ public class TurnitinImplTest extends AbstractJUnit4SpringContextTests {
 		tiiService.setServerConfigurationService(M_conf);
 		expect(M_conf.getServerUrl()).andStubReturn("http://serverurl");
 		expect(M_conf.getInt("contentreview.instructions.max", 1000)).andStubReturn(1000);
+		expect(M_conf.getInt("contentreview.due.date.queue.job.buffer.minutes", 0)).andStubReturn(0);
 		replay(M_conf);
 		
 		M_man = createMock(SessionManager.class);


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/TII-245

When creating an assignment, the assignments tool passes the due date to turnitin.

From the turnitin end, it allows you to submit after the due date only if you haven't already submitted.

Since our attachments are treated as individual submissions, we encounter scenarios where a student submits two attachments late, one gets through, the other is rejected (it is past the due date, and a submission exists in TII).

The due date we send should be the latest of the accept until date or the resubmit accept until (these can appear in any order). But consider that you can set the resubmit accept until for individual submitters.

Introduces sakai.property:
contentreview.due.date.queue.job.buffer.minutes=(minutes to extend TII due date after the latest accept until date; default = 0)