### PR TITLE
TII-248: improve handling of group submissions

### DIFF
--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/hbm/BaseReviewServiceImpl.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/hbm/BaseReviewServiceImpl.java
@@ -113,9 +113,9 @@ public abstract class BaseReviewServiceImpl implements ContentReviewService {
 	
 		log.debug("Method called queueContent(" + userId + "," + siteId + "," + contentId + ")");
 
-		if (userId == null) {
-			log.debug("Using current user");
-			userId = userDirectoryService.getCurrentUser().getId();
+		if (StringUtils.isBlank(userId))
+		{
+			throw new QueueException("Unable to queue content item " + contentId + ", a userId was not provided.");
 		}
 
 		if (siteId == null) {
@@ -150,47 +150,6 @@ public abstract class BaseReviewServiceImpl implements ContentReviewService {
 		if(isResubmission){
 			item.setResubmission(true);
 		}
-		dao.save(item);
-	}
-	
-	public void queueContent(String userId, String siteId, String taskId, String contentId)
-			throws QueueException {
-	
-		log.debug("Method called queueContent(" + userId + "," + siteId + "," + contentId + ")");
-
-		if (userId == null) {
-			log.debug("Using current user");
-			userId = userDirectoryService.getCurrentUser().getId();
-		}
-
-		if (siteId == null) {
-			log.debug("Using current site");
-			siteId = toolManager.getCurrentPlacement().getContext();
-		}
-
-		if (taskId == null) {
-			log.debug("Generating default taskId");
-			taskId = siteId + " " + defaultAssignmentName;
-		}
-
-		log.debug("Adding content: " + contentId + " from site " + siteId
-					+ " and user: " + userId + " for task: " + taskId + " to submission queue");
-
-		/*
-		 * first check that this content has not been submitted before this may
-		 * not be the best way to do this - perhaps use contentId as the primary
-		 * key for now id is the primary key and so the database won't complain
-		 * if we put in repeats necessitating the check
-		 */
-
-		List<ContentReviewItem> existingItems = getItemsByContentId(contentId);
-		if (existingItems.size() > 0) {
-			throw new QueueException("Content " + contentId + " is already queued, not re-queued");
-		}
-		ContentReviewItem item = new ContentReviewItem(userId, siteId, taskId, contentId, new Date(),
-			ContentReviewItem.NOT_SUBMITTED_CODE);
-		item.setNextRetryTime(new Date());
-		item.setUrlAccessed(false);
 		dao.save(item);
 	}
 

--- a/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinReviewServiceImpl.java
+++ b/contentreview-impl/impl/src/java/org/sakaiproject/contentreview/impl/turnitin/TurnitinReviewServiceImpl.java
@@ -1488,11 +1488,22 @@ public class TurnitinReviewServiceImpl extends BaseReviewServiceImpl {
 							log.debug("Submission " + sub.getId());
 							boolean allowAnyFile = asn.getContent().isAllowAnyFile();
 							List<ContentResource> resources = getAllAcceptableAttachments(sub,allowAnyFile);
+
+							// determine the owner of the submission for purposes of content review
+							String ownerId = asn.isGroup() ? sub.getSubmittedForGroupByUserId() : sub.getSubmitterId();
+							if (ownerId.isEmpty())
+							{
+								String msg = "Unable to submit content items to review service for submission %s to assignment %s. "
+										+ "An appropriate owner for the submission cannot be determined.";
+								log.warn(String.format(msg, sub.getId(), asn.getId()));
+								continue;
+							}
+
 							for(ContentResource resource : resources){
 								//if it wasnt added
 								if(getFirstItemByContentId(resource.getId()) == null){
-									log.debug("was not added");								
-									queueContent(sub.getSubmitterId(), null, asn.getReference(), resource.getId(), sub.getId(), false);
+									log.debug("was not added");
+									queueContent(ownerId, null, asn.getReference(), resource.getId(), sub.getId(), false);
 								}
 								//else - is there anything or any status we should check?
 							}

--- a/contentreview-impl/impl/src/test/org/sakaiproject/contentreview/logic/TurnitinImplTest.java
+++ b/contentreview-impl/impl/src/test/org/sakaiproject/contentreview/logic/TurnitinImplTest.java
@@ -288,7 +288,6 @@ public class TurnitinImplTest extends AbstractJUnit4SpringContextTests {
 		replay(cr);
 		List<ContentResource> contents = new ArrayList();
 		contents.add(cr);
-		//tiiService.queueContent("userId", "siteId", "taskId", "contentId", "submissionId");
 		tiiService.queueContent("userId", "siteId", "taskId", contents, "submissionId", false);
 		
 		//TEST 2


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/TII-248

Group assignments have been problematic for content review because the
submitter is recorded as the group and not an individual user. While it
is fairly straightforward to overcome this at the time of submission,
other scenarios exist where submissions are queued for content review
well after the student submits. These uncommon scenarios were partially
addressed by using the content file's creator as a submitter, but this
isn't accurate for situations where the instructor has submitted on
behalf of a student in the group.

This patch addresses these concerns by adding a feature to assignment
submissions to record the individual user who makes the submission for a
group. This information is then used by the content review service to
determine the appropriate "owner" of a group submission for the purposes
of content review.